### PR TITLE
fix: correct negative bar scaling and default styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.2.2
+* Fixed negative bar scaling so widths are proportional to absolute values
+* Disabled negative bars by default and added transparent fill with a visible series-colored outline
+* Kept negative data labels readable when negative bars use the default transparent fill
+
 ## 3.2.1.0
 * Added new translations
 * Updated packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.2.2
+## 3.2.2.0
 * Fixed negative bar scaling so widths are proportional to absolute values
 * Disabled negative bars by default and added transparent fill with a visible series-colored outline
 * Kept negative data labels readable when negative bars use the default transparent fill

--- a/src/TornadoChart.ts
+++ b/src/TornadoChart.ts
@@ -880,7 +880,7 @@ export class TornadoChart implements IVisual {
 
     private renderColumns(columnsData: TornadoChartPoint[], isFormatMode: boolean): void {  
         // Hide negative bars when the negative bars toggle is turned off
-        const showNegativeBars = this.formattingSettings?.negativeBars?.show?.value ?? true;
+        const showNegativeBars = this.formattingSettings?.negativeBars?.show?.value ?? false;
         const filteredColumnsData = showNegativeBars
             ? columnsData
             : columnsData.filter(p => p.value >= 0);
@@ -914,8 +914,8 @@ export class TornadoChart implements IVisual {
         columnsSelectionMerged
             .style("stroke", (p: TornadoChartPoint) => {
                 let strokeColor: string;
-                if (p.value < 0 && this.formattingSettings?.negativeBars?.borderColor?.value?.value) {
-                    strokeColor = this.formattingSettings.negativeBars.borderColor.value.value;
+                if (p.value < 0) {
+                    strokeColor = this.formattingSettings?.negativeBars?.borderColor?.value?.value || p.color;
                 } else {
                     const borderColor = this.formattingSettings?.barAppearance?.borderColor?.value?.value;
                     strokeColor = borderColor || p.color;
@@ -995,10 +995,16 @@ export class TornadoChart implements IVisual {
     }
 
     private getColumnWidth(value: number, minValue: number, maxValue: number, width: number): number {
-        if (minValue === maxValue) {
-            return width;
+        if (!Number.isFinite(value) || !Number.isFinite(minValue) || !Number.isFinite(maxValue) || width <= 0) {
+            return 0;
         }
-        const columnWidth = width * (value - minValue) / (maxValue - minValue);
+
+        const domainMagnitude = Math.max(Math.abs(minValue), Math.abs(maxValue));
+        if (domainMagnitude === 0) {
+            return 0;
+        }
+
+        const columnWidth = width * Math.abs(value) / domainMagnitude;
 
         // In case the user specifies a custom category axis end we limit the
         // column width to the maximum available width
@@ -1052,11 +1058,16 @@ export class TornadoChart implements IVisual {
         const valueAfterValueFormatter: string = textMeasurementService.getTailoredTextOrDefault(textProperties, maxLabelWidth);
         const textDataAfterValueFormatter: TextData = TornadoChart.getTextData(valueAfterValueFormatter, this.formattingSettings.dataLabels.labelsValuesGroup.font, true, false);
         const negativeFill = this.formattingSettings.dataLabels.labelsValuesGroup.negativeFill?.value?.value;
+        const negativeBarsTransparency = this.formattingSettings.negativeBars?.transparency?.value ?? 0;
+        const transparentNegativeFill = value < 0 && negativeBarsTransparency === 100
+            ? this.formattingSettings.dataLabels.labelsValuesGroup.outsideFill.value.value || this.themeForegroundColor
+            : null;
+        const negativeLabelFill = negativeFill || transparentNegativeFill;
 
         if (columnWidth > textDataAfterValueFormatter.width + TornadoChart.LabelPadding) {
             dx = dxColumn + columnWidth / 2 - textDataAfterValueFormatter.width / 2;
-            if (value < 0 && negativeFill) {
-                color = negativeFill;
+            if (value < 0 && negativeLabelFill) {
+                color = negativeLabelFill;
             }
         } else {
             if (isColumnPositionLeft) {
@@ -1064,8 +1075,8 @@ export class TornadoChart implements IVisual {
             } else {
                 dx = dxColumn + columnWidth + this.leftLabelMargin;
             }
-            if (value < 0 && negativeFill) {
-                color = negativeFill;
+            if (value < 0 && negativeLabelFill) {
+                color = negativeLabelFill;
             } else {
                 color = this.formattingSettings.dataLabels.labelsValuesGroup.outsideFill.value.value || this.themeForegroundColor;
             }
@@ -1164,7 +1175,7 @@ export class TornadoChart implements IVisual {
 
         // When negative bars are hidden their columns aren't rendered, so suppress
         // the matching labels (kept in the join to preserve per-row alignment).
-        const showNegativeBars: boolean = this.formattingSettings?.negativeBars?.show?.value ?? true;
+        const showNegativeBars: boolean = this.formattingSettings?.negativeBars?.show?.value ?? false;
         const isLabelHidden = (p: TornadoChartPoint): boolean => !showNegativeBars && p.value < 0;
 
         const labelFontFamily : string = formattingSettings.dataLabels.labelsValuesGroup.font.fontFamily.value;
@@ -1201,7 +1212,7 @@ export class TornadoChart implements IVisual {
 
         labelSelectionMerged
             .select(TornadoChart.LabelText.selectorName)
-            .attr("fill", (p: TornadoChartPoint) => this.colorHelper.isHighContrast ? this.colorHelper.getHighContrastColor("foreground", p.color) : p.label!.color)
+            .attr("fill", (p: TornadoChartPoint) => this.colorHelper.isHighContrast ? this.colorHelper.getHighContrastColor("foreground", p.label!.color) : p.label!.color)
             .attr("font-size", fontSizeInPx)
             .attr("font-family", labelFontFamily)
             .attr("font-weight", labelFontIsBold ? "bold" : "normal")

--- a/src/TornadoChart.ts
+++ b/src/TornadoChart.ts
@@ -269,6 +269,7 @@ export class TornadoChart implements IVisual {
                     seriesMax: seriesMax,
                     formatString,
                     color: dataPointColor,
+                    seriesColor: parsedSeries.fill,
                     selected: false,
                     identity,
                     categoryIndex: i,
@@ -915,7 +916,7 @@ export class TornadoChart implements IVisual {
             .style("stroke", (p: TornadoChartPoint) => {
                 let strokeColor: string;
                 if (p.value < 0) {
-                    strokeColor = this.formattingSettings?.negativeBars?.borderColor?.value?.value || p.color;
+                    strokeColor = this.formattingSettings?.negativeBars?.borderColor?.value?.value || p.seriesColor;
                 } else {
                     const borderColor = this.formattingSettings?.barAppearance?.borderColor?.value?.value;
                     strokeColor = borderColor || p.color;

--- a/src/TornadoChartSettingsModel.ts
+++ b/src/TornadoChartSettingsModel.ts
@@ -83,10 +83,12 @@ class NegativeBarsCardSettings extends Card {
 
     transparency = new formattingSettings.Slider({
         name: "transparency",
-        displayName: "Transparency (%)",
+        displayName: "Transparency",
         displayNameKey: "Visual_Transparency",
         value: 100,
         options: {
+            unitSymbol: "%",
+            unitSymbolAfterInput: true,
             minValue: {
                 type: powerbiVisualsApi.visuals.ValidatorType.Min,
                 value: 0,
@@ -107,10 +109,12 @@ class NegativeBarsCardSettings extends Card {
 
     borderWidth = new formattingSettings.Slider({
         name: "borderWidth",
-        displayName: "Border width (px)",
+        displayName: "Border width",
         displayNameKey: "Visual_BorderWidth",
         value: 2,
         options: {
+            unitSymbol: "px",
+            unitSymbolAfterInput: true,
             minValue: {
                 type: powerbiVisualsApi.visuals.ValidatorType.Min,
                 value: 0,
@@ -124,10 +128,12 @@ class NegativeBarsCardSettings extends Card {
 
     cornerRadius = new formattingSettings.Slider({
         name: "cornerRadius",
-        displayName: "Rounded corners (px)",
+        displayName: "Rounded corners",
         displayNameKey: "Visual_CornerRadius",
         value: 0,
         options: {
+            unitSymbol: "px",
+            unitSymbolAfterInput: true,
             minValue: {
                 type: powerbiVisualsApi.visuals.ValidatorType.Min,
                 value: 0,
@@ -155,10 +161,12 @@ class BarAppearanceCardSettings extends Card {
 
     borderWidth = new formattingSettings.Slider({
         name: "borderWidth",
-        displayName: "Border width (px)",
+        displayName: "Border width",
         displayNameKey: "Visual_BorderWidth",
         value: 0,
         options: {
+            unitSymbol: "px",
+            unitSymbolAfterInput: true,
             minValue: {
                 type: powerbiVisualsApi.visuals.ValidatorType.Min,
                 value: 0,
@@ -172,10 +180,12 @@ class BarAppearanceCardSettings extends Card {
 
     cornerRadius = new formattingSettings.Slider({
         name: "cornerRadius",
-        displayName: "Rounded corners (px)",
+        displayName: "Rounded corners",
         displayNameKey: "Visual_CornerRadius",
         value: 0,
         options: {
+            unitSymbol: "px",
+            unitSymbolAfterInput: true,
             minValue: {
                 type: powerbiVisualsApi.visuals.ValidatorType.Min,
                 value: 0,
@@ -189,10 +199,12 @@ class BarAppearanceCardSettings extends Card {
 
     barSpacing = new formattingSettings.Slider({
         name: "barSpacing",
-        displayName: "Space between bars (%)",
+        displayName: "Space between bars",
         displayNameKey: "Visual_BarSpacing",
         value: 0,
         options: {
+            unitSymbol: "%",
+            unitSymbolAfterInput: true,
             minValue: {
                 type: powerbiVisualsApi.visuals.ValidatorType.Min,
                 value: 0,
@@ -229,10 +241,12 @@ class CenterLineCardSettings extends Card {
 
     width = new formattingSettings.Slider({
         name: "width",
-        displayName: "Width (px)",
+        displayName: "Width",
         displayNameKey: "Visual_Width",
         value: 1,
         options: {
+            unitSymbol: "px",
+            unitSymbolAfterInput: true,
             minValue: {
                 type: powerbiVisualsApi.visuals.ValidatorType.Min,
                 value: 1,

--- a/src/TornadoChartSettingsModel.ts
+++ b/src/TornadoChartSettingsModel.ts
@@ -69,7 +69,7 @@ class NegativeBarsCardSettings extends Card {
         name: "show",
         displayName: "Show",
         displayNameKey: "Visual_Show",
-        value: true
+        value: false
     });
 
     topLevelSlice? = this.show;
@@ -85,7 +85,7 @@ class NegativeBarsCardSettings extends Card {
         name: "transparency",
         displayName: "Transparency (%)",
         displayNameKey: "Visual_Transparency",
-        value: 0,
+        value: 100,
         options: {
             minValue: {
                 type: powerbiVisualsApi.visuals.ValidatorType.Min,
@@ -109,7 +109,7 @@ class NegativeBarsCardSettings extends Card {
         name: "borderWidth",
         displayName: "Border width (px)",
         displayNameKey: "Visual_BorderWidth",
-        value: 0,
+        value: 2,
         options: {
             minValue: {
                 type: powerbiVisualsApi.visuals.ValidatorType.Min,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -89,6 +89,7 @@ export interface TornadoChartPoint {
     height?: number;
     label?: LabelData;
     color: string;
+    seriesColor: string;
     tooltipData: VisualTooltipDataItem[];
     categoryIndex: number;
     highlight?: boolean;

--- a/stringResources/en-US/resources.resjson
+++ b/stringResources/en-US/resources.resjson
@@ -49,9 +49,9 @@
     "Visual_OnObject_FormatLabels": "Format labels",
     "Visual_Options": "Options",
     "Visual_NegativeBars": "Negative bars",
-    "Visual_Transparency": "Transparency (%)",
+    "Visual_Transparency": "Transparency",
     "Visual_CenterLine": "Center line",
-    "Visual_Width": "Width (px)",
+    "Visual_Width": "Width",
     "Visual_ChartArea": "Chart Area",
     "Visual_BackgroundColor": "Background color",
     "Visual_Axis_Normalize": "Normalize to 100%",
@@ -62,7 +62,7 @@
     "Visual_DataLabels_NegativeFill": "Negative fill",
     "Visual_BarAppearance": "Bar appearance",
     "Visual_BorderColor": "Border color",
-    "Visual_BorderWidth": "Border width (px)",
-    "Visual_CornerRadius": "Rounded corners (px)",
-    "Visual_BarSpacing": "Space between bars (%)"
+    "Visual_BorderWidth": "Border width",
+    "Visual_CornerRadius": "Rounded corners",
+    "Visual_BarSpacing": "Space between bars"
 }

--- a/test/helpers/helpers.ts
+++ b/test/helpers/helpers.ts
@@ -35,8 +35,27 @@ export function getSolidColorStructuralObject(color: string): any {
 }
 
 export function areColorsEqual(firstColor: string, secondColor: string): boolean {
-    const firstConvertedColor: RgbColor = parseColorString(firstColor),
-        secondConvertedColor: RgbColor = parseColorString(secondColor);
+    const normalizeColor = (color: string): RgbColor | undefined => {
+        const parsedColor = parseColorString(color);
+        if (parsedColor) {
+            return parsedColor;
+        }
+
+        const element = document.createElement("span");
+        element.style.color = color;
+        document.body.appendChild(element);
+        const normalizedColor = parseColorString(getComputedStyle(element).color);
+        element.remove();
+
+        return normalizedColor;
+    };
+
+    const firstConvertedColor = normalizeColor(firstColor),
+        secondConvertedColor = normalizeColor(secondColor);
+
+    if (!firstConvertedColor || !secondConvertedColor) {
+        return false;
+    }
 
     return firstConvertedColor.R === secondConvertedColor.R
         && firstConvertedColor.G === secondConvertedColor.G

--- a/test/visualTest.ts
+++ b/test/visualTest.ts
@@ -485,6 +485,74 @@ describe("TornadoChart", () => {
                 (<number[]>dataView.categorical!.values![0].values)[0] = -500;
             });
 
+            it("are hidden by default", () => {
+                dataView.metadata.objects = {};
+
+                visualBuilder.updateFlushAllD3Transitions(dataView);
+
+                const renderedNegativeValues: number[] = Array.from(visualBuilder.columns)
+                    .map((element: SVGPathElement) => (<TornadoChartPoint>(<any>element).__data__).value)
+                    .filter((value: number) => value < 0);
+                expect(renderedNegativeValues).toEqual([]);
+            });
+
+            it("scale proportionally to absolute magnitude", () => {
+                const values: number[] = <number[]>dataView.categorical!.values![0].values;
+                values.splice(0, values.length, -120000, -45000, 0, 45000, 120000, 60000);
+
+                visualBuilder.updateFlushAllD3Transitions(dataView);
+
+                const renderedPoints: TornadoChartPoint[] = Array.from(visualBuilder.columns)
+                    .map((element: SVGPathElement) => <TornadoChartPoint>(<any>element).__data__);
+                const mostNegative: TornadoChartPoint = renderedPoints.find((point: TornadoChartPoint) => point.value === -120000)!;
+                const smallerNegative: TornadoChartPoint = renderedPoints.find((point: TornadoChartPoint) => point.value === -45000)!;
+                const matchingPositive: TornadoChartPoint = renderedPoints.find((point: TornadoChartPoint) => point.value === 120000)!;
+
+                expect(mostNegative.width).toBeGreaterThan(0);
+                expect(mostNegative.width! / smallerNegative.width!).toBeCloseTo(120000 / 45000, 5);
+                expect(mostNegative.width).toBeCloseTo(matchingPositive.width!, 5);
+            });
+
+            it("use transparent fill and a series-colored outline when enabled", () => {
+                visualBuilder.updateFlushAllD3Transitions(dataView);
+
+                const negativeColumn: SVGPathElement = Array.from(visualBuilder.columns)
+                    .find((element: SVGPathElement) => (<TornadoChartPoint>(<any>element).__data__).value < 0)!;
+                const negativePoint: TornadoChartPoint = <TornadoChartPoint>(<any>negativeColumn).__data__;
+                const styles: CSSStyleDeclaration = getComputedStyle(negativeColumn);
+
+                expect(parseFloat(styles.getPropertyValue("fill-opacity"))).toBeCloseTo(0, 5);
+                expect(styles.getPropertyValue("stroke-width")).toBe("2px");
+                expect(negativeColumn.style.stroke).toBe(negativePoint.color);
+            });
+
+            it("show readable labels when the default fill is transparent", () => {
+                visualBuilder.updateFlushAllD3Transitions(dataView);
+
+                const negativeLabel: HTMLElement = Array.from(visualBuilder.labels)
+                    .find((element: HTMLElement) => (<TornadoChartPoint>(<any>element).__data__).value < 0)!;
+                const labelText: SVGTextElement = negativeLabel.querySelector("text.label-text")!;
+                const outsideFill = visualBuilder.instance.formattingSettings.dataLabels.labelsValuesGroup.outsideFill.value.value;
+
+                expect(labelText.textContent).toBeTruthy();
+                expect(labelText.getAttribute("fill")).toBe(outsideFill);
+            });
+
+            it("use the configured negative label fill", () => {
+                const color = "#123456";
+                dataView.metadata.objects!.labels = {
+                    negativeFill: getSolidColorStructuralObject(color)
+                };
+
+                visualBuilder.updateFlushAllD3Transitions(dataView);
+
+                const negativeLabel: HTMLElement = Array.from(visualBuilder.labels)
+                    .find((element: HTMLElement) => (<TornadoChartPoint>(<any>element).__data__).value < 0)!;
+                const labelText: SVGTextElement = negativeLabel.querySelector("text.label-text")!;
+
+                expect(labelText.getAttribute("fill")).toBe(color);
+            });
+
             it("show", (done) => {
                 visualBuilder.updateRenderTimeout(dataView, () => {
                     expect(dataView.metadata.objects!["negativeBars"].show).toBe(true);
@@ -562,7 +630,6 @@ describe("TornadoChart", () => {
             });
 
             it("cornerRadius", () => {
-                // Ensure a negative bar with non-zero width (the most negative value maps to zero width)
                 (<number[]>dataView.categorical!.values![0].values)[0] = -300;
                 (<number[]>dataView.categorical!.values![0].values)[1] = -900;
 

--- a/test/visualTest.ts
+++ b/test/visualTest.ts
@@ -497,16 +497,29 @@ describe("TornadoChart", () => {
             });
 
             it("scale proportionally to absolute magnitude", () => {
-                const values: number[] = <number[]>dataView.categorical!.values![0].values;
-                values.splice(0, values.length, -120000, -45000, 0, 45000, 120000, 60000);
+                dataViewBuilder.valuesValue1 = [-120000, -45000, 0, 45000, 120000, 60000];
+                dataViewBuilder.valuesValue2 = [0, 0, 0, 0, 0, 0];
+                dataView = dataViewBuilder.getDataView();
+                dataView.metadata.objects = {
+                    negativeBars: {
+                        show: true
+                    }
+                };
 
                 visualBuilder.updateFlushAllD3Transitions(dataView);
 
                 const renderedPoints: TornadoChartPoint[] = Array.from(visualBuilder.columns)
                     .map((element: SVGPathElement) => <TornadoChartPoint>(<any>element).__data__);
-                const mostNegative: TornadoChartPoint = renderedPoints.find((point: TornadoChartPoint) => point.value === -120000)!;
-                const smallerNegative: TornadoChartPoint = renderedPoints.find((point: TornadoChartPoint) => point.value === -45000)!;
-                const matchingPositive: TornadoChartPoint = renderedPoints.find((point: TornadoChartPoint) => point.value === 120000)!;
+                const mostNegative = renderedPoints.find((point: TornadoChartPoint) => point.value === -120000);
+                const smallerNegative = renderedPoints.find((point: TornadoChartPoint) => point.value === -45000);
+                const matchingPositive = renderedPoints.find((point: TornadoChartPoint) => point.value === 120000);
+
+                expect(mostNegative).toBeDefined();
+                expect(smallerNegative).toBeDefined();
+                expect(matchingPositive).toBeDefined();
+                if (!mostNegative || !smallerNegative || !matchingPositive) {
+                    return;
+                }
 
                 expect(mostNegative.width).toBeGreaterThan(0);
                 expect(mostNegative.width! / smallerNegative.width!).toBeCloseTo(120000 / 45000, 5);
@@ -523,7 +536,7 @@ describe("TornadoChart", () => {
 
                 expect(parseFloat(styles.getPropertyValue("fill-opacity"))).toBeCloseTo(0, 5);
                 expect(styles.getPropertyValue("stroke-width")).toBe("2px");
-                expect(negativeColumn.style.stroke).toBe(negativePoint.color);
+                expect(negativeColumn.style.stroke).toBe(negativePoint.seriesColor);
             });
 
             it("show readable labels when the default fill is transparent", () => {
@@ -574,18 +587,22 @@ describe("TornadoChart", () => {
                 expect(visualBuilder.columns.length).toBeLessThan(renderedWhenShown);
             });
 
-            it("fill", (done) => {
+            it("uses the configured fill without changing the border color", () => {
                 const color: string = "#AABB11";
                 (dataView.metadata.objects!).negativeBars.fill = getSolidColorStructuralObject(color);
 
-                visualBuilder.updateRenderTimeout(dataView, () => {
-                    // The negative bar's gradient should be painted with the configured fill color
-                    const stopColorMatches: boolean = Array.from(visualBuilder.gradients)
-                        .some((gradient: SVGElement) => Array.from(gradient.querySelectorAll("stop"))
-                            .some((stop: Element) => areColorsEqual(stop.getAttribute("stop-color") || "", color)));
-                    expect(stopColorMatches).toBe(true);
-                    done();
-                });
+                visualBuilder.updateFlushAllD3Transitions(dataView);
+
+                const negativeColumn: SVGPathElement = Array.from(visualBuilder.columns)
+                    .find((element: SVGPathElement) => (<TornadoChartPoint>(<any>element).__data__).value < 0)!;
+                const negativePoint: TornadoChartPoint = <TornadoChartPoint>(<any>negativeColumn).__data__;
+                const negativeGradient: SVGElement = Array.from(visualBuilder.gradients)
+                    .find((gradient: SVGElement) => (<TornadoChartPoint>(<any>gradient).__data__).uniqId === negativePoint.uniqId)!;
+                const stopColors = Array.from(negativeGradient.querySelectorAll("stop"))
+                    .map((stop: Element) => stop.getAttribute("stop-color") || "");
+
+                expect(stopColors.some((stopColor: string) => areColorsEqual(stopColor, color))).toBe(true);
+                expect(negativeColumn.style.stroke).toBe(negativePoint.seriesColor);
             });
 
             it("transparency", (done) => {

--- a/test/visualTest.ts
+++ b/test/visualTest.ts
@@ -536,7 +536,9 @@ describe("TornadoChart", () => {
 
                 expect(parseFloat(styles.getPropertyValue("fill-opacity"))).toBeCloseTo(0, 5);
                 expect(styles.getPropertyValue("stroke-width")).toBe("2px");
-                expect(negativeColumn.style.stroke).toBe(negativePoint.seriesColor);
+                expect(areColorsEqual(
+                    styles.getPropertyValue("stroke"),
+                    negativePoint.seriesColor)).toBe(true);
             });
 
             it("show readable labels when the default fill is transparent", () => {
@@ -602,7 +604,9 @@ describe("TornadoChart", () => {
                     .map((stop: Element) => stop.getAttribute("stop-color") || "");
 
                 expect(stopColors.some((stopColor: string) => areColorsEqual(stopColor, color))).toBe(true);
-                expect(negativeColumn.style.stroke).toBe(negativePoint.seriesColor);
+                expect(areColorsEqual(
+                    getComputedStyle(negativeColumn).getPropertyValue("stroke"),
+                    negativePoint.seriesColor)).toBe(true);
             });
 
             it("transparency", (done) => {


### PR DESCRIPTION
### Corrects negative-bar scaling and introduces the requested default appearance and visibility behavior.

#### Changes

- Scales positive and negative bars proportionally using absolute magnitude.
- Prevents the largest negative value from collapsing to zero width.
- Hides negative bars by default.
- Uses a fully transparent fill, 2 px outline, and corresponding series color when negative bars are enabled.
- Keeps negative labels readable when the bar fill is transparent.
- Preserves explicitly configured negative-bar and label colors.
- Corrects label colors in high-contrast mode.
- Adds regression tests for scaling, styling, visibility, and labels.
- Updates the changelog.

#### Validation

- TypeScript compilation passed.
- ESLint passed.
- All 67 tests passed.
- Power BI visual packaging passed.
- Manual rendering and formatting checks passed.

#### Backward compatibility
Existing reports without a persisted negativeBars.show value will receive the new default value of false. Product confirmation is required before merging to confirm whether this behavior is acceptable or requires a migration strategy.